### PR TITLE
Remove hardcoded shell from CreateUserJob.cpp

### DIFF
--- a/src/modules/users/CreateUserJob.cpp
+++ b/src/modules/users/CreateUserJob.cpp
@@ -149,8 +149,6 @@ CreateUserJob::exec()
     int ec = CalamaresUtils::System::instance()->
              targetEnvCall( { "useradd",
                               "-m",
-                              "-s",
-                              "/bin/bash",
                               "-U",
                               "-c",
                               m_fullName,


### PR DESCRIPTION
If necessary a file `/etc/default/useradd` can handle the shell

```
# useradd defaults file for Manjaro Linux
# useradd defaults file for ArchLinux
# original changes by TomK
GROUP=users
HOME=/home
INACTIVE=-1
EXPIRE=
SHELL=/bin/bash
SKEL=/etc/skel
CREATE_MAIL_SPOOL=no
```

This file can then be replaced if desired in the overlay filesystem